### PR TITLE
Feature/multi twitter account tests

### DIFF
--- a/app/firebase/functions/.gitignore
+++ b/app/firebase/functions/.gitignore
@@ -10,3 +10,5 @@ node_modules/
 
 .env.*
 .secret.*
+
+test/__tests__/test_user_data.json

--- a/app/firebase/functions/src/platforms/platforms.interface.ts
+++ b/app/firebase/functions/src/platforms/platforms.interface.ts
@@ -1,10 +1,21 @@
-import { UserDetailsBase, WithPlatformUserId } from '../@shared/types';
+import {
+  PLATFORM,
+  UserDetailsBase,
+  WithPlatformUserId,
+} from '../@shared/types';
 import { AppPostPublish, PlatformPost } from '../@shared/types.posts';
 
-export interface FetchUserPostsParams {
+/** use conditional types to dynamically assign credential types for each platform */
+export type CredentialsForPlatform<P> = P extends PLATFORM.Twitter
+  ? { accessToken: string }
+  : any;
+
+export interface FetchUserPostsParams<P extends PLATFORM> {
   user_id: string;
   start_time: number; // timestamp in ms
-  credentials: any;
+  /** end_time is useful for testing and some platforms may need to explicitely define the end time of the fetch */
+  end_time?: number; // timestamp in ms
+  credentials: CredentialsForPlatform<P>;
 }
 
 export interface IdentityService<
@@ -27,7 +38,7 @@ export interface PlatformService<
   SignupData = any,
   UserDetails extends UserDetailsBase = WithPlatformUserId,
 > extends IdentityService<SignupContext, SignupData, UserDetails> {
-  fetch(params: FetchUserPostsParams[]): Promise<any[]>;
+  fetch(params: FetchUserPostsParams<PLATFORM>[]): Promise<any[]>;
   convertToGeneric(platformPost: PlatformPost): GenericPostData;
   publish(
     post: AppPostPublish,

--- a/app/firebase/functions/src/platforms/platforms.interface.ts
+++ b/app/firebase/functions/src/platforms/platforms.interface.ts
@@ -38,7 +38,7 @@ export interface PlatformService<
   SignupData = any,
   UserDetails extends UserDetailsBase = WithPlatformUserId,
 > extends IdentityService<SignupContext, SignupData, UserDetails> {
-  fetch(params: FetchUserPostsParams<PLATFORM>[]): Promise<any[]>;
+  fetch(params: FetchUserPostsParams<PLATFORM>[]): Promise<PlatformPost[]>;
   convertToGeneric(platformPost: PlatformPost): GenericPostData;
   publish(
     post: AppPostPublish,

--- a/app/firebase/functions/src/platforms/platforms.service.ts
+++ b/app/firebase/functions/src/platforms/platforms.service.ts
@@ -10,7 +10,10 @@ import {
   PlatformService,
 } from './platforms.interface';
 
-export type FetchAllUserPostsParams = Map<PLATFORM, FetchUserPostsParams[]>;
+export type FetchAllUserPostsParams = Map<
+  PLATFORM,
+  FetchUserPostsParams<PLATFORM>[]
+>;
 export type PlatformsMap = Map<
   PLATFORM,
   PlatformService<any, any, WithPlatformUserId>

--- a/app/firebase/functions/src/platforms/twitter/twitter.service.ts
+++ b/app/firebase/functions/src/platforms/twitter/twitter.service.ts
@@ -40,9 +40,14 @@ export class TwitterService
 {
   constructor(protected credentials: TwitterApiCredentials) {}
 
+  /**
+   *
+   * @param dateStr ISO 8601 date string, e.g. '2021-09-01T00:00:00Z'
+   * @returns unix timestamp in milliseconds
+   */
   public dateStrToTimestampMs(dateStr: string) {
-    // TODO: implement the conversion
-    return 10000;
+    const date = new Date(dateStr);
+    return date.getTime();
   }
 
   private getGenericClient() {

--- a/app/firebase/functions/test/__tests__/02-platforms.test.ts
+++ b/app/firebase/functions/test/__tests__/02-platforms.test.ts
@@ -25,7 +25,7 @@ describe('platforms', () => {
       try {
         const tweets = await twitterService.fetch([
           {
-            user_id: '1753077743816777728',
+            user_id: TEST_TOKENS_MAP[TWITTER_ACCOUNT].user_id,
             start_time: 1708560000000,
             end_time: 1708646400000,
             credentials: {

--- a/app/firebase/functions/test/__tests__/02-platforms.test.ts
+++ b/app/firebase/functions/test/__tests__/02-platforms.test.ts
@@ -5,6 +5,12 @@ import { logger } from '../../src/instances/logger';
 import { resetDB } from '../__tests_support__/db';
 import { services } from './test.services';
 
+const TWITTER_ACCOUNT = 'sensemakergod';
+
+const TEST_TOKENS_MAP = JSON.parse(
+  process.env.TEST_USERS_BEARER_TOKENS as string
+);
+
 describe('platforms', () => {
   before(async () => {
     logger.debug('resetting DB');
@@ -22,7 +28,7 @@ describe('platforms', () => {
             user_id: '1753077743816777728',
             start_time: 1708560000000,
             credentials: {
-              accessToken: process.env.TWITTER_MY_BEARER_TOKEN,
+              accessToken: TEST_TOKENS_MAP[TWITTER_ACCOUNT].accessToken,
             },
           },
         ]);

--- a/app/firebase/functions/test/__tests__/02-platforms.test.ts
+++ b/app/firebase/functions/test/__tests__/02-platforms.test.ts
@@ -27,13 +27,14 @@ describe('platforms', () => {
           {
             user_id: '1753077743816777728',
             start_time: 1708560000000,
+            end_time: 1708646400000,
             credentials: {
               accessToken: TEST_TOKENS_MAP[TWITTER_ACCOUNT].accessToken,
             },
           },
         ]);
         expect(tweets).to.not.be.undefined;
-        expect(tweets.length).to.be.equal(0);
+        expect(tweets.length).to.be.equal(11);
       } catch (error) {
         console.error('error: ', error);
         throw error;

--- a/app/firebase/functions/test/__tests__/test_user_data.sample.json
+++ b/app/firebase/functions/test/__tests__/test_user_data.sample.json
@@ -1,0 +1,14 @@
+[
+  {
+    "account_id": "",
+    "username": "",
+    "password": "",
+    "refresh_token": ""
+  },
+  {
+    "account_id": "",
+    "username": "",
+    "password": "",
+    "refresh_token": ""
+  }
+]


### PR DESCRIPTION
because of #32 , we can't create a stable access token for testing. Therefore I've instead set up tests that use a valid refresh token and then refresh the access token. The problem with this is that refreshing a token creates a new refresh token and invalidates the old one. 

Basically, if we want to have comprehensive testing of a user-wide twitter api client instance, we will probably want our own set of test accounts so that we aren't invalidating the other persons copy of the refresh token.