### PR TITLE
Feature/twitter threads

### DIFF
--- a/app/firebase/functions/package.json
+++ b/app/firebase/functions/package.json
@@ -32,7 +32,7 @@
     "node-fetch": "^3.3.2",
     "node-forge": "^1.3.1",
     "oauth-1.0a": "^2.2.6",
-    "twitter-api-v2": "^1.16.0",
+    "twitter-api-v2": "^1.16.2",
     "viem": "^2.7.10",
     "yup": "^1.3.3"
   },

--- a/app/firebase/functions/package.json
+++ b/app/firebase/functions/package.json
@@ -26,7 +26,7 @@
     "express": "^4.18.2",
     "fetch-sparql-endpoint": "^4.1.1",
     "firebase-admin": "^12.1.0",
-    "firebase-functions": "^5.0.0",
+    "firebase-functions": "^5.0.1",
     "jsonwebtoken": "^9.0.2",
     "n3": "^1.17.2",
     "node-fetch": "^3.3.2",

--- a/app/firebase/functions/src/platforms/platforms.interface.ts
+++ b/app/firebase/functions/src/platforms/platforms.interface.ts
@@ -14,7 +14,7 @@ export type CredentialsForPlatform<P> = P extends PLATFORM.Twitter
   : any;
 
 export interface FetchUserPostsParams {
-  start_time: number; // timestamp in ms
+  start_time?: number; // timestamp in ms
   end_time?: number; // timestamp in ms
   max_results?: number;
   userDetails: UserDetailsBase;

--- a/app/firebase/functions/src/platforms/twitter/twitter.service.ts
+++ b/app/firebase/functions/src/platforms/twitter/twitter.service.ts
@@ -514,16 +514,20 @@ export class TwitterService
   }
 
   public async convertToGeneric(
-    platformPost: PlatformPostCreate<TweetV2>
+    platformPost: PlatformPostCreate<TwitterThread>
   ): Promise<GenericPostData> {
     if (!platformPost.posted) {
       throw new Error('Unexpected undefined posted');
     }
-    const tweet = platformPost.posted.post;
+    const thread = platformPost.posted.post;
+    /** concatinate all tweets in thread into one app post */
+    const threadText = thread.tweets
+      .map((tweet) =>
+        tweet['note_tweet']?.text ? tweet['note_tweet'].text : tweet.text
+      )
+      .join('\n---\n');
     return {
-      content: tweet['note_tweet']?.text
-        ? tweet['note_tweet'].text
-        : tweet.text,
+      content: threadText,
     };
   }
 

--- a/app/firebase/functions/src/platforms/twitter/twitter.service.ts
+++ b/app/firebase/functions/src/platforms/twitter/twitter.service.ts
@@ -37,7 +37,11 @@ import { logger } from '../../instances/logger';
 import { TimeService } from '../../time/time.service';
 import { UsersRepository } from '../../users/users.repository';
 import { FetchUserPostsParams, PlatformService } from '../platforms.interface';
-import { dateStrToTimestampMs, handleTwitterError } from './twitter.utils';
+import {
+  dateStrToTimestampMs,
+  getTweetTextWithUrls,
+  handleTwitterError,
+} from './twitter.utils';
 
 const DEBUG = true;
 
@@ -521,11 +525,7 @@ export class TwitterService
     }
     const thread = platformPost.posted.post;
     /** concatinate all tweets in thread into one app post */
-    const threadText = thread.tweets
-      .map((tweet) =>
-        tweet['note_tweet']?.text ? tweet['note_tweet'].text : tweet.text
-      )
-      .join('\n---\n');
+    const threadText = thread.tweets.map(getTweetTextWithUrls).join('\n---\n');
     return {
       content: threadText,
     };

--- a/app/firebase/functions/src/platforms/twitter/twitter.service.ts
+++ b/app/firebase/functions/src/platforms/twitter/twitter.service.ts
@@ -2,7 +2,6 @@ import {
   TOAuth2Scope,
   TTweetv2TweetField,
   TweetV2,
-  TweetV2PaginableTimelineResult,
   TweetV2SingleResult,
   TweetV2UserTimelineParams,
   Tweetv2FieldsParams,
@@ -462,18 +461,8 @@ export class TwitterService
       const twitterThreads: TwitterThread[] = [];
 
       tweetThreadsMap.forEach((tweets, conversation_id) => {
-        /** sort tweets in thread by timestamp */
-        tweets.sort((tweetA, tweetB) => {
-          if (!tweetA.created_at || !tweetB.created_at) {
-            throw new Error(
-              `Unexpected created_at undefined, how would we know the timestamp then? )`
-            );
-          }
-          return (
-            dateStrToTimestampMs(tweetA.created_at) -
-            dateStrToTimestampMs(tweetB.created_at)
-          );
-        });
+        /** sort tweets in thread by id so that they are in order */
+        tweets.sort((tweetA, tweetB) => Number(tweetA.id) - Number(tweetB.id));
         twitterThreads.push({ conversation_id, tweets });
       });
 

--- a/app/firebase/functions/src/platforms/twitter/twitter.service.ts
+++ b/app/firebase/functions/src/platforms/twitter/twitter.service.ts
@@ -379,7 +379,6 @@ export class TwitterService
       'author_id',
       'text',
       'entities',
-      // @ts-ignore
       'note_tweet',
     ];
 
@@ -500,9 +499,11 @@ export class TwitterService
     if (!platformPost.posted) {
       throw new Error('Unexpected undefined posted');
     }
-
+    const tweet = platformPost.posted.post;
     return {
-      content: platformPost.posted.post.text,
+      content: tweet['note_tweet']?.text
+        ? tweet['note_tweet'].text
+        : tweet.text,
     };
   }
 

--- a/app/firebase/functions/src/platforms/twitter/twitter.utils.ts
+++ b/app/firebase/functions/src/platforms/twitter/twitter.utils.ts
@@ -1,4 +1,4 @@
-import { ApiResponseError } from 'twitter-api-v2';
+import { ApiResponseError, TweetV2 } from 'twitter-api-v2';
 
 export const handleTwitterError = (e: ApiResponseError) => {
   return `
@@ -18,4 +18,18 @@ export const handleTwitterError = (e: ApiResponseError) => {
 export const dateStrToTimestampMs = (dateStr: string) => {
   const date = new Date(dateStr);
   return date.getTime();
+};
+
+export const getTweetTextWithUrls = (tweet: TweetV2) => {
+  const fullTweet = tweet['note_tweet'] ? tweet['note_tweet'] : tweet;
+  const urls = fullTweet.entities?.urls;
+  let text = fullTweet.text;
+
+  if (urls) {
+    urls.forEach((url) => {
+      text = text.replace(url.url, url.expanded_url);
+    });
+  }
+
+  return text;
 };

--- a/app/firebase/functions/src/posts/posts.task.ts
+++ b/app/firebase/functions/src/posts/posts.task.ts
@@ -56,6 +56,7 @@ async function getFunctionUrl(name: string, location: string) {
   if (!auth) {
     auth = new GoogleAuth({
       scopes: 'https://www.googleapis.com/auth/cloud-platform',
+      projectId: 'sensenets-staging',
     });
   }
   const projectId = await auth.getProjectId();

--- a/app/firebase/functions/test/__tests__/02-platforms.test.ts
+++ b/app/firebase/functions/test/__tests__/02-platforms.test.ts
@@ -14,7 +14,7 @@ import { createTestAppUsers } from '../utils/user.factory';
 import { USE_REAL_NANOPUB, USE_REAL_PARSER, USE_REAL_TWITTER } from './setup';
 import { getTestServices } from './test.services';
 
-describe.only('02-platforms', () => {
+describe('02-platforms', () => {
   let rsaKeys: RSAKeys | undefined;
   let appUser: AppUser | undefined;
 

--- a/app/firebase/functions/test/__tests__/02-platforms.test.ts
+++ b/app/firebase/functions/test/__tests__/02-platforms.test.ts
@@ -14,7 +14,7 @@ import { createTestAppUsers } from '../utils/user.factory';
 import { USE_REAL_NANOPUB, USE_REAL_PARSER, USE_REAL_TWITTER } from './setup';
 import { getTestServices } from './test.services';
 
-describe('02-platforms', () => {
+describe.only('02-platforms', () => {
   let rsaKeys: RSAKeys | undefined;
   let appUser: AppUser | undefined;
 
@@ -37,7 +37,7 @@ describe('02-platforms', () => {
   });
 
   describe('twitter', () => {
-    it("get's all tweets in a time range using pagination", async () => {
+    it.only("get's the latest 5 threads", async () => {
       if (!appUser) {
         throw new Error('appUser not created');
       }
@@ -62,16 +62,20 @@ describe('02-platforms', () => {
             ...userDetails,
             user_id: '1773032135814717440',
           },
-          start_time: 1708560000000,
-          end_time: 1708646400000,
+          end_time: 1714786027000,
+          max_results: 5,
         };
 
-        const tweets = await services.db.run((manager) =>
+        const threads = await services.db.run((manager) =>
           twitterService.fetch(fetchParams, manager)
         );
 
-        expect(tweets).to.not.be.undefined;
-        expect(tweets.length).to.be.equal(6);
+        expect(threads).to.not.be.undefined;
+        expect(threads.length).to.be.equal(5);
+        expect(threads[0].post.tweets.length).to.be.equal(5);
+        expect(threads[0].post.conversation_id).to.be.equal(
+          '1786430246264152195'
+        );
       } catch (error) {
         console.error('error: ', error);
         throw error;

--- a/app/firebase/functions/test/__tests__/03-post.process.test.ts
+++ b/app/firebase/functions/test/__tests__/03-post.process.test.ts
@@ -14,7 +14,7 @@ import { createTestAppUsers } from '../utils/user.factory';
 import { USE_REAL_NANOPUB, USE_REAL_PARSER, USE_REAL_TWITTER } from './setup';
 import { getTestServices } from './test.services';
 
-describe('03-process', () => {
+describe.only('03-process', () => {
   let rsaKeys: RSAKeys | undefined;
   const services = getTestServices({
     twitter: USE_REAL_TWITTER ? 'real' : 'mock-publish',
@@ -105,7 +105,7 @@ describe('03-process', () => {
       const postsRead = await services.postsManager.getOfUser(appUser.userId);
 
       expect(postsRead).to.not.be.undefined;
-      expect(postsRead).to.have.length(3);
+      expect(postsRead).to.have.length(1);
 
       const postRead = postsRead[0];
       expect(postRead).to.not.be.undefined;
@@ -141,7 +141,7 @@ describe('03-process', () => {
       const postsRead = await services.postsManager.getOfUser(appUser.userId);
 
       expect(postsRead).to.not.be.undefined;
-      expect(postsRead).to.have.length(3);
+      expect(postsRead).to.have.length(1);
 
       postsRead.forEach((postRead) => {
         expect(postRead.semantics).to.not.be.undefined;
@@ -160,7 +160,7 @@ describe('03-process', () => {
         appUser.userId
       );
 
-      expect(pendingPosts).to.have.length(3);
+      expect(pendingPosts).to.have.length(1);
       const pendingPost = pendingPosts[0];
       const nanopub = pendingPost.mirrors.find(
         (m) => m.platformId === PLATFORM.Nanopub

--- a/app/firebase/functions/yarn.lock
+++ b/app/firebase/functions/yarn.lock
@@ -1883,10 +1883,10 @@ firebase-functions-test@^3.1.0:
     lodash "^4.17.5"
     ts-deepmerge "^2.0.1"
 
-firebase-functions@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/firebase-functions/-/firebase-functions-5.0.0.tgz#bbe2b9b31f4161825849d5d2c9ea4cfa7d3e88cc"
-  integrity sha512-iGG41MavOS+RtEsbcq2j/ltQ8L2Oji71dRpwVur+meIQWkvXCYb2QJtnyp0ryQVnV3NyjV+3Vdx7OnmD+Hanuw==
+firebase-functions@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/firebase-functions/-/firebase-functions-5.0.1.tgz#90f241f9231faac8a8cf4f3468b93b4b86bb348c"
+  integrity sha512-1m+crtgAR8Tl36gjpM02KCY5zduAejFmDSXvih/DB93apg39f0U/WwRgT7sitGIRqyCcIpktNUbXJv7Y9JOF4A==
   dependencies:
     "@types/cors" "^2.8.5"
     "@types/express" "4.17.3"

--- a/app/firebase/functions/yarn.lock
+++ b/app/firebase/functions/yarn.lock
@@ -3675,10 +3675,10 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-twitter-api-v2@^1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/twitter-api-v2/-/twitter-api-v2-1.16.0.tgz#4aff58c402168a4582d1dc5a58ecfe3144ac620c"
-  integrity sha512-e7wzWqx5oQZ9IUc2xt8JiJ84ioVGlmjmca1h0NwCKx2AFfKXDePmQa42gcBDe0qau9YaHsIpzO9z5SX1fmb+IQ==
+twitter-api-v2@^1.16.2:
+  version "1.16.3"
+  resolved "https://registry.yarnpkg.com/twitter-api-v2/-/twitter-api-v2-1.16.3.tgz#6042c61b4dee35329dda3d153d9f08d2c6a348e3"
+  integrity sha512-T9Wbq1y3IrTshBvtVawpWp1GmL3mduF4RhieSfM1HsL10Qda0EeJMDUwr5C6IeelnSZ65tiiXzs0xUS8FHM9XA==
 
 type-detect@^4.0.0, type-detect@^4.0.8:
   version "4.0.8"

--- a/app/webapp/src/shared/types/types.twitter.ts
+++ b/app/webapp/src/shared/types/types.twitter.ts
@@ -1,5 +1,6 @@
 import {
   IOAuth2RequestTokenResult,
+  TweetV2,
   TweetV2PostTweetResult,
   UserV2,
 } from 'twitter-api-v2';
@@ -52,3 +53,8 @@ export interface TwitterQueryParameters {
 export interface TwitterDraft {
   text: string;
 }
+
+export type TwitterThread = {
+  conversation_id: string;
+  tweets: TweetV2[];
+};


### PR DESCRIPTION
The way this works is that setting `max_results` passed in when calling `fetch` now assumes this is the max number of *threads* to return. Meaning, the twitter API will continue to be called (if necessary), until that many threads are reached. In case there are more, the rest are cut off.

This only really matters for the initial part of using the app when we are populating it with tweets for the first time.