### PR TITLE
include all info in profile when setting platform details

### DIFF
--- a/app/firebase/functions/src/users/users.repository.ts
+++ b/app/firebase/functions/src/users/users.repository.ts
@@ -328,12 +328,21 @@ export class UsersRepository {
 
     manager.update(userRef, update);
 
-    // update mirror collection profiles
+    // update or create mirror collection profiles
     if (details.profile) {
       const profileRef = this.db.collections.profiles.doc(
         getProfileId(userId, platform, details.user_id)
       );
-      manager.set(profileRef, { profile: details.profile }, { merge: true });
+      manager.set(
+        profileRef,
+        {
+          userId,
+          profile: details.profile,
+          platformId: platform,
+          user_id: details.user_id,
+        },
+        { merge: true }
+      );
     }
   }
 


### PR DESCRIPTION
hey @pepoospina realised I made a slight fix in my branches that we might want to merge into development separately. 
It just makes sure we include `platformId` `userId` and `user_id` in the profile documents.
It works for the first profile created, but this fix makes sure that info is included in profiles that are added after the first.
<img width="540" alt="image" src="https://github.com/user-attachments/assets/5136265e-b1e1-4176-80a1-4e06f3b055b3">
<img width="538" alt="image" src="https://github.com/user-attachments/assets/5d608a99-38d0-44d2-8975-d05852ee8803">
