### PR TITLE
check if post card is in a ref overlay view and conditionally show ag…

### DIFF
--- a/app/webapp/src/semantics/patterns/refs-labels/RefWithLabels.tsx
+++ b/app/webapp/src/semantics/patterns/refs-labels/RefWithLabels.tsx
@@ -1,6 +1,7 @@
 import { Box } from 'grommet';
 import { useMemo } from 'react';
 
+import { useOverlay } from '../../../overlays/OverlayContext';
 import { ParserOntology, RefMeta } from '../../../shared/types/types.parser';
 import { RefLabel } from '../../../shared/types/types.references';
 import { AppLabelsEditor } from '../../../ui-components/AppLabelsEditor';
@@ -28,6 +29,7 @@ export const RefWithLabels = (props: {
   const refData = props.refData;
   const { showLabels } =
     props.showLabels !== undefined ? props : { showLabels: true };
+  const overlay = useOverlay()?.overlay;
 
   /** display names for selected labels */
   let labelsDisplayNames = useMemo(
@@ -118,7 +120,7 @@ export const RefWithLabels = (props: {
         </Box>
       )}
 
-      {show ? (
+      {show && (!overlay?.ref || props.showDescription) ? (
         <Box margin={{ top: '22px' }}>
           <AggregatedRefLabels
             refLabels={refLabels}


### PR DESCRIPTION
…gregated labels

@pepoospina there is some strange behaviour with the `OverlayContext`. I think because it is nested. It exists at the Feed and User Page level, but also in each specific overlay component (`RefOverlay` for example). So it seems what ends up happening is that the overlay state gets reset once a new overlay is set. I tried removing the `OverlayContext` components in each of the specific overlay components, but then it lost the ability to track the nesting of overlays. 